### PR TITLE
提案: 登録元タブのタイトルとURLを予定の詳細に追加

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,5 +8,6 @@
             ],
             "url": "http://json.schemastore.org/chrome-manifest"
         }
-    ]
+    ],
+    "editor.formatOnSave": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,6 +8,5 @@
             ],
             "url": "http://json.schemastore.org/chrome-manifest"
         }
-    ],
-    "editor.formatOnSave": false,
+    ]
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -16,6 +16,7 @@
   },
 
   "permissions": [
-    "contextMenus"
+    "contextMenus",
+    "tabs"
   ]
 }

--- a/src/background.ts
+++ b/src/background.ts
@@ -19,10 +19,18 @@ chrome.contextMenus.onClicked.addListener((info) => {
 
   const selectedText = info.selectionText?.trim();
   if (selectedText) {
-    const { textWithoutDate, startDateTime, endDateTime } = extractDateTime(selectedText);
+    chrome.tabs.query({ active: true, lastFocusedWindow: true }, (tabs) => {
+      const currentTitle = tabs[0].title || "";
+      const currentUrl = tabs[0].url || "";
+      const currentTab = `${currentTitle}\n${currentUrl}`;
 
-    calendarUrl.searchParams.append("text", textWithoutDate);
-    if (startDateTime) calendarUrl.searchParams.append("dates", startDateTime.format(DATE_FORMAT) + "/" + endDateTime.format(DATE_FORMAT));
+      const { textWithoutDate, startDateTime, endDateTime } = extractDateTime(selectedText);
+
+      calendarUrl.searchParams.append("text", textWithoutDate);
+      if (startDateTime) calendarUrl.searchParams.append("dates", startDateTime.format(DATE_FORMAT) + "/" + endDateTime.format(DATE_FORMAT));
+      calendarUrl.searchParams.append("details", currentTab);
+
+      chrome.tabs.create({ url: calendarUrl.href });
+    });
   }
-  chrome.tabs.create({ url: calendarUrl.href });
 });

--- a/src/background.ts
+++ b/src/background.ts
@@ -11,12 +11,12 @@ chrome.runtime.onInstalled.addListener((details) => {
   });
 });
 
-const GetCurrentTabInfo = async (): Promise<chrome.tabs.Tab[]> => {
+const getCurrentTabInfo = async (): Promise<chrome.tabs.Tab[]> => {
   return await chrome.tabs.query({ active: true, lastFocusedWindow: true });
 }
 
-const GetCurrentTabMessage = async (): Promise<string> => {
-  const tabs = await GetCurrentTabInfo();
+const getCurrentTabMessage = async (): Promise<string> => {
+  const tabs = await getCurrentTabInfo();
   const currentTitle = tabs[0].title || "";
   const currentUrl = tabs[0].url || "";
   const currentTab = `${currentTitle}\n${currentUrl}`;
@@ -35,7 +35,7 @@ chrome.contextMenus.onClicked.addListener(async (info) => {
 
       calendarUrl.searchParams.append("text", textWithoutDate);
       if (startDateTime) calendarUrl.searchParams.append("dates", startDateTime.format(DATE_FORMAT) + "/" + endDateTime.format(DATE_FORMAT));
-      const currentTab = await GetCurrentTabMessage();
+      const currentTab = await getCurrentTabMessage();
       calendarUrl.searchParams.append("details", currentTab);
 
       chrome.tabs.create({ url: calendarUrl.href });


### PR DESCRIPTION
chrome上から選択したテキストでGoogleカレンダーに予定を追加できる拡張を探していたところ、「Google Calendar Quick Add」にたどり着きました。
予定を追加する際、日時を自動で入力してくれる機能が欲しかったため、こちらを使わせていただきます。

カレンダーに登録する際、登録元のテキストのタブのタイトルとURLも予定に記録できれば、「何の予定だったか」「どこから登録したか」を後から確認しやすくなるのではないかと思い、機能の追加を提案させていただきます。

具体的な変更点は以下の通りです。

・chrome.tabs.queryを使って現在のタブのタイトルとURLを取得し、
　calendarUrl.searchParams.append("details", currentTab)でURLのdetailsに追加しました。
・manifest.jsonのpermissionsにtabsも追加しました。
。chrome.tabs.queryが非同期処理であるため、一旦URLへのappend処理全体をchrome.tabs.query内に囲いました。

動作自体はは問題なく行えるはずですのでお試しいただき、よしなにご判断いただければと思います。
