### PR TITLE
Feat/use chrono node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
+        "chrono-node": "^2.8.2",
         "dayjs": "^1.11.13",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -1798,6 +1799,17 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/chrono-node": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.8.2.tgz",
+      "integrity": "sha512-7BJ6TRHs4sFtOSsTISWXGKjg7C70wD+NU+44uA6euGnbvZnECvgzUv+5TS9sICta2sBQWej4UYy8XAg4W9E7rQ==",
+      "dependencies": {
+        "dayjs": "^1.10.0"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
     "node_modules/ci-info": {
       "version": "3.8.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.8.0.tgz",
@@ -2336,20 +2348,6 @@
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
       "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
       "dev": true
-    },
-    "node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
     },
     "node_modules/function-bind": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "url": "https://github.com/chibat/chrome-extension-typescript-starter.git"
   },
   "dependencies": {
+    "chrono-node": "^2.8.2",
     "dayjs": "^1.11.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -3,7 +3,7 @@
 
   "name": "Google Calendar Quick Add",
   "description": "選択したテキストをGoogleカレンダーの予定に追加します。",
-  "version": "1.0.3",
+  "version": "1.0.4",
 
   "icons": {
     "16": "icons/icon16.png",

--- a/src/__tests__/extract.ts
+++ b/src/__tests__/extract.ts
@@ -1,42 +1,18 @@
-import { extractDateTime, dateRegex } from "../extract";
+import { extractDateTime } from "../extract";
 import dayjs from "dayjs";
 import objectSupport from "dayjs/plugin/objectSupport";
 
 dayjs.extend(objectSupport);
 
-describe("regex", () => {
-    test("should null", () => {
-        expect("aaaaa".match(dateRegex)).toBeNull();
-    });
-
-    test("should match full date and time", () => {
-        const match = "2025/03/10 14:30".match(dateRegex)
-        if (match) {
-            expect(match[1]).toBe("2025");
-            expect(match[2]).toBe("03");
-        }
-    });
-    test("should handle short date format", () => {
-        const match = "7/4 18:00".match(dateRegex)
-        expect(match).not.toBeNull();
-        if (match) {
-            expect(match[1]).toBe(undefined);
-            expect(match[2]).toBe("7");
-            expect(match[3]).toBe("4");
-            expect(match[4]).toBe("18");
-            expect(match[5]).toBe("00");
-        }
-    });
-});
-
 
 describe("extractDateTime function", () => {
-    test("should extract null", () => {
+    const currentYear = new Date().getFullYear();
+    test("should extract undefined", () => {
         expect(extractDateTime("aaaaaaaaa")).toEqual(
             {
                 textWithoutDate: "aaaaaaaaa",
-                startDateTime: null,
-                endDateTime: null
+                startDateTime: undefined,
+                endDateTime: undefined
             }
         );
     });
@@ -50,7 +26,6 @@ describe("extractDateTime function", () => {
     });
 
     test("should handle date without year", () => {
-        const currentYear = new Date().getFullYear();
         expect(extractDateTime("3月10日 9時15分")).toEqual({
             textWithoutDate: "",
             startDateTime: dayjs({year: currentYear, month: 3 - 1, day: 10, hour: 9, minute: 15}),
@@ -61,17 +36,50 @@ describe("extractDateTime function", () => {
     test("should handle date without time", () => {
         expect(extractDateTime("2024年5月20日")).toEqual({
             textWithoutDate: "",
-            startDateTime: dayjs({year: 2024, month: 5 - 1, day: 20, hour: 0, minute: 0}),
-            endDateTime: dayjs({year: 2024, month: 5 - 1, day: 20, hour: 1, minute: 0})
+            startDateTime: dayjs({year: 2024, month: 5 - 1, day: 20, hour: 12, minute: 0}),
+            endDateTime: dayjs({year: 2024, month: 5 - 1, day: 20, hour: 13, minute: 0})
         });
     });
 
     test("should handle short date format", () => {
-        const currentYear = new Date().getFullYear();
         expect(extractDateTime("7/4 18:00")).toEqual({
             textWithoutDate: "",
             startDateTime: dayjs({year: currentYear, month: 7 - 1, day: 4, hour: 18, minute: 0}),
             endDateTime: dayjs({year: currentYear, month: 7 - 1, day: 4, hour: 19, minute: 0})
         });
     });
+
+    test("should handle zenkaku short date format", () => {
+        expect(extractDateTime("７／４　１８：００")).toEqual({
+            textWithoutDate: "",
+            startDateTime: dayjs({year: currentYear, month: 7 - 1, day: 4, hour: 18, minute: 0}),
+            endDateTime: dayjs({year: currentYear, month: 7 - 1, day: 4, hour: 19, minute: 0})
+        });
+    });
 });
+
+
+describe("extractDateTime function range", () => {
+    const currentYear = new Date().getFullYear();
+    test("should extract full date and time", () => {
+        expect(extractDateTime("ミーティング 2025/03/10 14:30 ~ 16:00")).toEqual({
+            textWithoutDate: "ミーティング ",
+            startDateTime: dayjs({year: 2025, month: 3 - 1, day: 10, hour: 14, minute: 30}),
+            endDateTime: dayjs({year: 2025, month: 3 - 1, day: 10, hour: 16, minute: 0})
+        });
+    });
+    test("should extract full date and time", () => {
+        expect(extractDateTime("展示会 2025/03/10 10:00 ~ 2025/03/11 17:00")).toEqual({
+            textWithoutDate: "展示会 ",
+            startDateTime: dayjs({year: 2025, month: 3 - 1, day: 10, hour: 10, minute: 0}),
+            endDateTime: dayjs({year: 2025, month: 3 - 1, day: 11, hour: 17, minute: 0})
+        });
+    });
+    test("should extract short date and short time", () => {
+        expect(extractDateTime("展示会 3月10日 10時 ～ 3月11日 17時")).toEqual({
+            textWithoutDate: "展示会 ",
+            startDateTime: dayjs({year: currentYear, month: 3 - 1, day: 10, hour: 10, minute: 0}),
+            endDateTime: dayjs({year: currentYear, month: 3 - 1, day: 11, hour: 17, minute: 0})
+        });
+    });
+})

--- a/src/__tests__/google_calendar.ts
+++ b/src/__tests__/google_calendar.ts
@@ -1,0 +1,37 @@
+import dayjs from "dayjs";
+import { describe, it, expect } from "@jest/globals";
+import { createGoogleCalendarUrl } from "../google_calendar";
+
+describe("createGoogleCalendarUrl", () => {
+  const details = "Test Title\nhttps://example.com";
+
+  it("should generate a URL with only text and details when no dates are provided", () => {
+    const url = createGoogleCalendarUrl("Event Title", details);
+    expect(url.origin + url.pathname).toBe("https://calendar.google.com/calendar/r/eventedit");
+    expect(url.searchParams.get("text")).toBe("Event Title");
+    expect(url.searchParams.get("details")).toBe(details);
+    expect(url.searchParams.get("dates")).toBeNull();
+  });
+
+  it("should generate a URL with text, details, and dates when start and end are provided", () => {
+    const start = dayjs("2024-06-01T10:00:00");
+    const end = dayjs("2024-06-01T11:00:00");
+    const url = createGoogleCalendarUrl("Meeting", details, start, end);
+    expect(url.searchParams.get("text")).toBe("Meeting");
+    expect(url.searchParams.get("details")).toBe(details);
+    expect(url.searchParams.get("dates")).toBe("20240601T100000/20240601T110000");
+  });
+
+  it("should not add dates param if dates are not provided", () => {
+    const url = createGoogleCalendarUrl("Title", details, undefined, undefined);
+    expect(url.searchParams.get("dates")).toBeNull();
+  });
+
+  it("should encode special characters in text and details", () => {
+    const specialText = "タイトル & 予定";
+    const specialDetails = "詳細: テスト\nhttps://example.com/?q=テスト";
+    const url = createGoogleCalendarUrl(specialText, specialDetails);
+    expect(url.searchParams.get("text")).toBe(specialText);
+    expect(url.searchParams.get("details")).toBe(specialDetails);
+  });
+});

--- a/src/extract.ts
+++ b/src/extract.ts
@@ -1,40 +1,25 @@
+import * as chrono from 'chrono-node';
 import dayjs from "dayjs";
 import objectSupport from "dayjs/plugin/objectSupport";
 
 dayjs.extend(objectSupport);
-const dateRegex =
-  /(\d{4})?[年\/\-]?(\d{1,2})[月\/\-]?(\d{1,2})日?(?:\s*(\d{1,2})[:時](\d{1,2})?)?[分]?/;
 
 function extractDateTime(text: string) {
-  const match = text.match(dateRegex);
+  const parsedResult = chrono.ja.parse(text);
 
-  if (!match) {
-    return { textWithoutDate: text, startDateTime: null, endDateTime: null };
+  if (parsedResult.length === 0) {
+    return {
+      textWithoutDate: text,
+      startDateTime: undefined,
+      endDateTime: undefined
+    };
   }
 
-  const now = dayjs();
-
-  const year = match[1] ? parseInt(match[1]) : now.year();
-  const month = match[2] ? parseInt(match[2]) : now.month() + 1;
-  const day = match[3] ? parseInt(match[3]) : now.date();
-  const hour = match[4] ? parseInt(match[4]) : 0;
-  const minute = match[5] ? parseInt(match[5]) : 0;
-
-  const start = dayjs({
-    year: year,
-    month: month - 1,
-    day: day,
-    hour: hour,
-    minute: minute,
-    second: 0,
-  });
-  const end = start.add(1, "hour");
-
   return {
-    textWithoutDate: text.replace(dateRegex, ""),
-    startDateTime: start,
-    endDateTime: end,
+    textWithoutDate: text.replace(parsedResult[0].text, ""),
+    startDateTime: dayjs(parsedResult[0].start.date()),
+    endDateTime: parsedResult[0].end ?  dayjs(parsedResult[0].end.date()) : dayjs(parsedResult[0].start.date()).add(1, 'hour')
   };
 }
 
-export { extractDateTime, dateRegex };
+export { extractDateTime };

--- a/src/google_calendar.ts
+++ b/src/google_calendar.ts
@@ -1,0 +1,21 @@
+import dayjs from "dayjs";
+
+const createGoogleCalendarUrl = (text: string, details: string, startDateTime?: dayjs.Dayjs, endDateTime?: dayjs.Dayjs): URL => {
+  const GOOGLE_CALENDAR_BASE_URL = "https://calendar.google.com/calendar/r/eventedit";
+  const DATE_FORMAT = "YYYYMMDDTHHmmss";
+
+  const calendarUrl = new URL(GOOGLE_CALENDAR_BASE_URL);
+  calendarUrl.searchParams.append("text", text);
+  
+  if (startDateTime && endDateTime) {
+    const startDateTimeString = startDateTime.format(DATE_FORMAT);
+    const endDateTimeString = endDateTime.format(DATE_FORMAT);
+    calendarUrl.searchParams.append("dates", startDateTimeString + "/" + endDateTimeString);
+  }
+
+  calendarUrl.searchParams.append("details", details);
+
+  return calendarUrl;
+}
+
+export { createGoogleCalendarUrl };


### PR DESCRIPTION
- 日付抽出に、ライブラリ[chrono-node](https://www.npmjs.com/package/chrono-node) を使用するようにした
  - これにより、開始日時と終了日時が抽出できるようになった。例：`2025/03/10 10:00 ~ 2025/03/11 17:00`
- バージョン番号を1.0.3から1.0.4に更新